### PR TITLE
pre-commit: move target directory from `entry` to `args`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,8 @@
 -   id: deptry
     name: deptry
     description: deptry is a command line tool to check for issues with dependencies in a Python project, such as unused or missing dependencies.
-    entry: deptry .
+    entry: deptry
+    args: [ "." ]
     language: python
     always_run: true
     pass_filenames: false


### PR DESCRIPTION
See also https://github.com/fpgmaas/deptry/pull/1392, I made that but then realized it's a `system` hook so I can't use it. Thanks for the mirror!

---

Previously, running deptry in pre-commit when using a `src` directory:
* with no args, results in `DEP003 'mypackage' imported but it is a transitive dependency`
* with `args: [ src ]`, results in double reports
* with `entry: deptry src`, provides the correct behavior

However, `entry` is supposed to be an internal implementation detail, while `args` is meant for users to override. In this PR I've moved the directory to `args` so it can be overridden by `args: [ "src" ]` instead.

This is a breaking change, since anyone using `args: [ "--something" ]` will now be running `deptry --something` instead of `deptry . --something`, and need to edit their config to `args: [ ".", "--something" ]`. So feel free to deny if this isn't important enough to warrant that.
