### PR TITLE
ci: fix workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,10 +5,14 @@ on:
   schedule:
   - cron: '30 8 * * *'
 
+permissions: {}
+
 jobs:
   build:
     name: main
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # for final git push
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1


### PR DESCRIPTION
It worked on my fork, for some reason the default permissions were set differently on my fork by default:
<img width="792" height="332" alt="image" src="https://github.com/user-attachments/assets/e8cede52-08b6-4777-b050-db4ce1ac6b5a" />
This PR sets the permissions explicitly.